### PR TITLE
currentSpeed: displayed aaverage 5s pace

### DIFF
--- a/source/FlexiRunnerApp-rectangle-148x205.mc
+++ b/source/FlexiRunnerApp-rectangle-148x205.mc
@@ -55,6 +55,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 	hidden var mStoppedTime 		= 0;
 	hidden var mStoppedDistance 	= 0;
 	hidden var mPrevElapsedDistance = 0;
+	
+	hidden const BUFFER_SIZE = 5;
+	hidden var mSpeedQueue          = null;
+	hidden var mCurrentSpeed        = 0;
 
 	hidden var uTargetPaceMetric = 0;	//! Which average pace metric should be used as the reference for deviation of the current pace? (see above)
 
@@ -102,6 +106,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
  		uBottomRightMetric		= mApp.getProperty("pBottomRightMetric");
  		uRoundedPace			= mApp.getProperty("pRoundedPace");
 
+		if (uRoundedPace) {
+			mSpeedQueue = new[BUFFER_SIZE];
+		} 
+		
         if (System.getDeviceSettings().paceUnits == System.UNIT_STATUTE) {
         	unitP = 1609.344;
         }
@@ -146,6 +154,21 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 				//! Simple non-moving time calculation - relies on compute() being called every second
 				mStoppedTime++;
 				mStoppedDistance += mDistanceIncrement;
+			} else {
+				if (uRoundedPace && info.currentSpeed != null) {
+					mSpeedQueue[(mTicker-1)%BUFFER_SIZE]=info.currentSpeed;
+				    var avg=0;
+				    var num=0;
+					for (var i=0; i<BUFFER_SIZE;i++) {
+			    		if (mSpeedQueue[i]!=null) {
+			    			avg += mSpeedQueue[i];
+			    			num++; 
+			    		}
+			    	}
+					mCurrentSpeed = avg/ num;
+				} else {
+					mCurrentSpeed = info.currentSpeed;
+				}
 			}			
 
 			//! Running economy: http://fellrnr.com/wiki/Running_Economy
@@ -262,6 +285,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 		
 		mTicker 	= 0;
 		mLapTicker	= 0;
+		if (uRoundedPace) {
+			mSpeedQueue = new[BUFFER_SIZE];
+		}
+		mCurrentSpeed = null; 
     }
 
 
@@ -361,7 +388,7 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 
 		//! Current pace vs target pace colour indicator
 		mColour = Graphics.COLOR_LT_GRAY;
-		if (info.currentSpeed != null && info.currentSpeed > 1.8) {	//! Only use the pace colour indicator when running (1.8 m/s = 9:15 min/km, ~15:00 min/mi)
+		if (mCurrentSpeed != null && mCurrentSpeed > 1.8) {	//! Only use the pace colour indicator when running (1.8 m/s = 9:15 min/km, ~15:00 min/mi)
 			var mTargetSpeed = 0.0;
 			if (uTargetPaceMetric == 0 && info.averageSpeed != null) {
 				mTargetSpeed = info.averageSpeed;
@@ -377,7 +404,7 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 				mTargetSpeed = mLastLapMovingSpeed;
 			}
 			if (mTargetSpeed > 0) {
-				var paceDeviation = (info.currentSpeed / mTargetSpeed);
+				var paceDeviation = (mCurrentSpeed / mTargetSpeed);
 				if (paceDeviation < 0.95) {	//! More than 5% slower
 					mColour = Graphics.COLOR_RED;
 				} else if (paceDeviation <= 1.05) {	//! Within +/-5% of target pace
@@ -478,14 +505,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 		dc.drawText(111, 5, Graphics.FONT_XTINY,  lDistance, Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 		
 		//! Centre middle: current pace
-		if (info.currentSpeed == null || info.currentSpeed < 0.447164) {
+		if (mCurrentSpeed == null || mCurrentSpeed < 0.447164) {
 			drawSpeedUnderlines(dc, 74, 81);
 		} else {
-			var fCurrentPace = info.currentSpeed;		
-			if (uRoundedPace) {
-				fCurrentPace = unitP/(Math.round( (unitP/info.currentSpeed) / 5 ) * 5);
-			}
-			dc.drawText(65, 74, Graphics.FONT_NUMBER_THAI_HOT, fmtPace(fCurrentPace), Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
+			dc.drawText(65, 74, Graphics.FONT_NUMBER_THAI_HOT, fmtPace(mCurrentSpeed), Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 		}
 		dc.drawText(2, 61, Graphics.FONT_XTINY,  "P", Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER);
 		dc.drawText(2, 71, Graphics.FONT_XTINY,  "a", Graphics.TEXT_JUSTIFY_LEFT|Graphics.TEXT_JUSTIFY_VCENTER);

--- a/source/FlexiRunnerApp-rectangle-205x148.mc
+++ b/source/FlexiRunnerApp-rectangle-205x148.mc
@@ -55,6 +55,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 	hidden var mStoppedTime 		= 0;
 	hidden var mStoppedDistance 	= 0;
 	hidden var mPrevElapsedDistance = 0;
+	
+	hidden const BUFFER_SIZE = 5;
+	hidden var mSpeedQueue          = null;
+	hidden var mCurrentSpeed        = 0;
 
 	hidden var uTargetPaceMetric = 0;	//! Which average pace metric should be used as the reference for deviation of the current pace? (see above)
 
@@ -102,6 +106,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
  		uBottomRightMetric		= mApp.getProperty("pBottomRightMetric");
  		uRoundedPace			= mApp.getProperty("pRoundedPace");
 
+		if (uRoundedPace) {
+			mSpeedQueue = new[BUFFER_SIZE];
+		} 
+		
         if (System.getDeviceSettings().paceUnits == System.UNIT_STATUTE) {
         	unitP = 1609.344;
         }
@@ -146,6 +154,21 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 				//! Simple non-moving time calculation - relies on compute() being called every second
 				mStoppedTime++;
 				mStoppedDistance += mDistanceIncrement;
+			} else {
+				if (uRoundedPace && info.currentSpeed != null) {
+					mSpeedQueue[(mTicker-1)%BUFFER_SIZE]=info.currentSpeed;
+				    var avg=0;
+				    var num=0;
+					for (var i=0; i<BUFFER_SIZE;i++) {
+			    		if (mSpeedQueue[i]!=null) {
+			    			avg += mSpeedQueue[i];
+			    			num++; 
+			    		}
+			    	}
+					mCurrentSpeed = avg/ num;
+				} else {
+					mCurrentSpeed = info.currentSpeed;
+				}
 			}			
 
 			//! Running economy: http://fellrnr.com/wiki/Running_Economy
@@ -262,6 +285,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 		
 		mTicker 	= 0;
 		mLapTicker	= 0;
+		if (uRoundedPace) {
+			mSpeedQueue = new[BUFFER_SIZE];
+		}
+		mCurrentSpeed = null; 
     }
 
 
@@ -361,7 +388,7 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 
 		//! Current pace vs target pace colour indicator
 		mColour = Graphics.COLOR_LT_GRAY;
-		if (info.currentSpeed != null && info.currentSpeed > 1.8) {	//! Only use the pace colour indicator when running (1.8 m/s = 9:15 min/km, ~15:00 min/mi)
+		if (mCurrentSpeed != null && mCurrentSpeed > 1.8) {	//! Only use the pace colour indicator when running (1.8 m/s = 9:15 min/km, ~15:00 min/mi)
 			var mTargetSpeed = 0.0;
 			if (uTargetPaceMetric == 0 && info.averageSpeed != null) {
 				mTargetSpeed = info.averageSpeed;
@@ -377,7 +404,7 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 				mTargetSpeed = mLastLapMovingSpeed;
 			}
 			if (mTargetSpeed > 0) {
-				var paceDeviation = (info.currentSpeed / mTargetSpeed);
+				var paceDeviation = (mCurrentSpeed / mTargetSpeed);
 				if (paceDeviation < 0.95) {	//! More than 5% slower
 					mColour = Graphics.COLOR_RED;
 				} else if (paceDeviation <= 1.05) {	//! Within +/-5% of target pace
@@ -485,14 +512,10 @@ class FlexiRunnerView extends Toybox.WatchUi.DataField {
 		dc.drawText(161, 6, Graphics.FONT_XTINY,  lDistance, Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 		
 		//! Centre middle: current pace
-		if (info.currentSpeed == null || info.currentSpeed < 0.447164) {
+		if (mCurrentSpeed == null || mCurrentSpeed < 0.447164) {
 			drawSpeedUnderlines(dc, 102, 89);
-		} else {
-			var fCurrentPace = info.currentSpeed;		
-			if (uRoundedPace) {
-				fCurrentPace = unitP/(Math.round( (unitP/info.currentSpeed) / 5 ) * 5);
-			}
-			dc.drawText(102, 90, Graphics.FONT_NUMBER_MEDIUM, fmtPace(fCurrentPace), Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
+		} else {	
+			dc.drawText(102, 90, Graphics.FONT_NUMBER_MEDIUM, fmtPace(mCurrentSpeed), Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 		}
 		dc.drawText(102, 60, Graphics.FONT_XTINY,  "Pace", Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 


### PR DESCRIPTION
Hi, 
Good work with FlexiRunner Field, I have only one caveat: i hate Garmin's rounded 5s currentSpeed.

So I've modified Datafield in order to average (5s average) info.currentSpeed: now instant pace is displayed with 1s precision.

If you like the patch, could you merge it?



